### PR TITLE
refactor: move getArrayPair to library

### DIFF
--- a/contracts/AsteroidsSplitContract.sol
+++ b/contracts/AsteroidsSplitContract.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./SpacePiratesTokens.sol";
-import "./libraries/Helpers.sol";
+import "./libraries/Array.sol";
 
 /**
  * @title Asteroids Split Contract
@@ -28,8 +28,8 @@ contract AsteroidsSplitContract {
         tokenContract.burn(msg.sender, amount, ASTEROIDS);
         tokenContract.mintBatch(
             msg.sender,
-            Helpers.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
-            Helpers.getArrayPair(amount, amount)
+            Array.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
+            Array.getArrayPair(amount, amount)
         );
 
         emit SplitAsteroids(msg.sender, amount);
@@ -38,8 +38,8 @@ contract AsteroidsSplitContract {
     function mergeAsteroids(uint256 amount) public {
         tokenContract.burnBatch(
             msg.sender,
-            Helpers.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
-            Helpers.getArrayPair(amount, amount)
+            Array.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
+            Array.getArrayPair(amount, amount)
         );
         tokenContract.mint(msg.sender, amount, ASTEROIDS);
 

--- a/contracts/AsteroidsSplitContract.sol
+++ b/contracts/AsteroidsSplitContract.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./SpacePiratesTokens.sol";
+import "./libraries/Helpers.sol";
 
 /**
  * @title Asteroids Split Contract
@@ -27,8 +28,8 @@ contract AsteroidsSplitContract {
         tokenContract.burn(msg.sender, amount, ASTEROIDS);
         tokenContract.mintBatch(
             msg.sender,
-            getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
-            getArrayPair(amount, amount)
+            Helpers.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
+            Helpers.getArrayPair(amount, amount)
         );
 
         emit SplitAsteroids(msg.sender, amount);
@@ -37,22 +38,11 @@ contract AsteroidsSplitContract {
     function mergeAsteroids(uint256 amount) public {
         tokenContract.burnBatch(
             msg.sender,
-            getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
-            getArrayPair(amount, amount)
+            Helpers.getArrayPair(VE_ASTEROIDS, STK_ASTEROIDS),
+            Helpers.getArrayPair(amount, amount)
         );
         tokenContract.mint(msg.sender, amount, ASTEROIDS);
 
         emit MergeAsteroids(msg.sender, amount);
-    }
-
-    function getArrayPair(uint256 x, uint256 y)
-        internal
-        pure
-        returns (uint256[] memory)
-    {
-        uint256[] memory array = new uint256[](2);
-        array[0] = x;
-        array[1] = y;
-        return array;
     }
 }

--- a/contracts/dex/ERC1155Batch.sol
+++ b/contracts/dex/ERC1155Batch.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "../libraries/Helpers.sol";
+import "../libraries/Array.sol";
 
 /**
  * @title ERC1155 Batch Contract
@@ -29,8 +29,8 @@ contract ERC1155Batch {
         IERC1155(tokenContract).safeBatchTransferFrom(
             from,
             to,
-            Helpers.getArrayPair(id0, id1),
-            Helpers.getArrayPair(amount0, amount1),
+            Array.getArrayPair(id0, id1),
+            Array.getArrayPair(amount0, amount1),
             ""
         );
     }
@@ -44,8 +44,8 @@ contract ERC1155Batch {
         uint256[] memory batchBalances = new uint256[](2);
 
         batchBalances = IERC1155(tokenContract).balanceOfBatch(
-            Helpers.getArrayPair(account, account),
-            Helpers.getArrayPair(id0, id1)
+            Array.getArrayPair(account, account),
+            Array.getArrayPair(id0, id1)
         );
 
         balance0 = batchBalances[0];

--- a/contracts/dex/ERC1155Batch.sol
+++ b/contracts/dex/ERC1155Batch.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "../libraries/Helpers.sol";
 
 /**
  * @title ERC1155 Batch Contract
@@ -16,28 +17,6 @@ contract ERC1155Batch {
         tokenContract = _tokenContract;
     }
 
-    function getArrayPair(uint256 x, uint256 y)
-        internal
-        pure
-        returns (uint256[] memory)
-    {
-        uint256[] memory array = new uint256[](2);
-        array[0] = x;
-        array[1] = y;
-        return array;
-    }
-
-    function getArrayPair(address x, address y)
-        internal
-        pure
-        returns (address[] memory)
-    {
-        address[] memory array = new address[](2);
-        array[0] = x;
-        array[1] = y;
-        return array;
-    }
-
     // avoids stack too deep errors
     function safeBatchTransferFromPair(
         address from,
@@ -50,8 +29,8 @@ contract ERC1155Batch {
         IERC1155(tokenContract).safeBatchTransferFrom(
             from,
             to,
-            getArrayPair(id0, id1),
-            getArrayPair(amount0, amount1),
+            Helpers.getArrayPair(id0, id1),
+            Helpers.getArrayPair(amount0, amount1),
             ""
         );
     }
@@ -65,8 +44,8 @@ contract ERC1155Batch {
         uint256[] memory batchBalances = new uint256[](2);
 
         batchBalances = IERC1155(tokenContract).balanceOfBatch(
-            getArrayPair(account, account),
-            getArrayPair(id0, id1)
+            Helpers.getArrayPair(account, account),
+            Helpers.getArrayPair(id0, id1)
         );
 
         balance0 = batchBalances[0];

--- a/contracts/libraries/Array.sol
+++ b/contracts/libraries/Array.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
  * @author @HenricoW
  * @notice Collection of utility functions
  */
-library Helpers {
+library Array {
     /**
      * @notice Convert pair of uint256 inputs to an array
      */

--- a/contracts/libraries/Helpers.sol
+++ b/contracts/libraries/Helpers.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title Helpers internal library
+ * @author @HenricoW
+ * @notice Collection of utility functions
+ */
+library Helpers {
+    /**
+     * @notice Convert pair of uint256 inputs to an array
+     */
+    function getArrayPair(uint256 x, uint256 y)
+        internal
+        pure
+        returns (uint256[] memory)
+    {
+        uint256[] memory array = new uint256[](2);
+        array[0] = x;
+        array[1] = y;
+        return array;
+    }
+
+    /**
+     * @notice Convert pair of address inputs to an array
+     */
+    function getArrayPair(address x, address y)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        address[] memory array = new address[](2);
+        array[0] = x;
+        array[1] = y;
+        return array;
+    }
+}


### PR DESCRIPTION
Closes #23 
Moved the two getArrayPair variants to a 'Helpers.sol' library. I called it that so that it could contain more minor utilities in future

Ran all test before and after, all tests are passing